### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Configuration:
 ```yaml
 steps:
 - plugins:
-    kubernetes-logs#v0.0.1:
-      label_query: "release=production,component=web"
-      namespace: default
+    - kubernetes-logs#v0.0.1:
+        label_query: "release=production,component=web"
+        namespace: default
 ```
 
 Dynamic:
@@ -33,5 +33,5 @@ steps:
 - command: |
     buildkite-agent meta-data set "KUBERNETES_LOGS_LABEL_QUERY" "release=production,component=web"
   plugins:
-    kubernetes-logs#v0.0.1: {}
+    - kubernetes-logs#v0.0.1: {}
 ```


### PR DESCRIPTION
Hi @jdotjdot! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.